### PR TITLE
feat(nocobot): config refactor + image vision support

### DIFF
--- a/nocobot/Dockerfile
+++ b/nocobot/Dockerfile
@@ -16,7 +16,9 @@ COPY providers/ ./nocobot/providers/
 RUN uv pip install --system --no-cache .
 
 # Run as non-root user
-RUN addgroup --system app && adduser --system --ingroup app app
+# --home is required: without it adduser defaults to /nonexistent,
+# which breaks Python's Path.home() and causes permission errors for media downloads.
+RUN addgroup --system app && adduser --system --home /home/app --ingroup app app
 RUN mkdir -p /home/app/.nocobot && chown app:app /home/app/.nocobot
 USER app
 

--- a/nocobot/Dockerfile
+++ b/nocobot/Dockerfile
@@ -7,7 +7,7 @@ COPY pyproject.toml LICENSE ./
 
 # Copy all source files into nocobot/ subdirectory to match package structure
 # (Docker context is nocobot/, so we recreate the package hierarchy)
-COPY __init__.py __main__.py main.py agent.py mcp_client.py config.py ratelimit.py ./nocobot/
+COPY __init__.py __main__.py main.py agent.py mcp_client.py config.py ratelimit.py vision.py ./nocobot/
 COPY bus/ ./nocobot/bus/
 COPY channels/ ./nocobot/channels/
 COPY providers/ ./nocobot/providers/

--- a/nocobot/agent.py
+++ b/nocobot/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from typing import Any
 
@@ -205,13 +206,17 @@ class AgentLoop:
         )
         skip = len(messages)  # new messages (including user msg) start here
         if msg.media:
+            # Strip "[image: /path]" placeholders — the actual image goes as a vision block
+            clean_text = re.sub(r"\[image: [^\]]+\]\n?", "", msg.content).strip()
             content = build_vision_content(
-                msg.content,
+                clean_text,
                 msg.media,
                 max_images=self._vision_max_images,
                 max_long_edge=self._vision_max_long_edge,
                 detail=self._vision_detail,
             )
+            n_images = sum(1 for p in content if p.get("type") == "image_url")
+            logger.debug(f"Built vision content: {n_images} image(s), text={clean_text[:80]!r}")
             messages.append({"role": "user", "content": content})
         else:
             messages.append({"role": "user", "content": msg.content})

--- a/nocobot/agent.py
+++ b/nocobot/agent.py
@@ -12,6 +12,7 @@ from nocobot.bus.events import InboundMessage, OutboundMessage
 from nocobot.bus.queue import MessageBus
 from nocobot.mcp_client import MCPClient
 from nocobot.providers import LiteLLMProvider, ToolCallRequest
+from nocobot.vision import build_vision_content
 
 
 class AgentLoop:
@@ -33,6 +34,9 @@ class AgentLoop:
         session_max_idle: float = 3600.0,
         llm_max_tokens: int = 4096,
         llm_temperature: float = 0.7,
+        vision_max_images: int = 5,
+        vision_max_long_edge: int = 1024,
+        vision_detail: str = "low",
     ):
         self.bus = bus
         self.mcp = mcp
@@ -45,6 +49,9 @@ class AgentLoop:
         self._session_max_idle = session_max_idle
         self._llm_max_tokens = llm_max_tokens
         self._llm_temperature = llm_temperature
+        self._vision_max_images = vision_max_images
+        self._vision_max_long_edge = vision_max_long_edge
+        self._vision_detail = vision_detail
         self._running = False
         self._semaphore = asyncio.Semaphore(max_concurrency)
         self._session_locks: dict[str, asyncio.Lock] = {}
@@ -197,7 +204,17 @@ class AgentLoop:
             + list(history)
         )
         skip = len(messages)  # new messages (including user msg) start here
-        messages.append({"role": "user", "content": msg.content})
+        if msg.media:
+            content = build_vision_content(
+                msg.content,
+                msg.media,
+                max_images=self._vision_max_images,
+                max_long_edge=self._vision_max_long_edge,
+                detail=self._vision_detail,
+            )
+            messages.append({"role": "user", "content": content})
+        else:
+            messages.append({"role": "user", "content": msg.content})
 
         # Get MCP tools
         tools = self.mcp.get_tools_for_llm()
@@ -306,6 +323,15 @@ class AgentLoop:
         """Persist new messages from the agent loop into session history."""
         for m in messages[skip:]:
             entry = dict(m)
+            # Strip image blocks from history to avoid persisting base64 blobs
+            content = entry.get("content")
+            if isinstance(content, list):
+                text_parts = [p["text"] for p in content if p.get("type") == "text"]
+                image_count = sum(1 for p in content if p.get("type") == "image_url")
+                summary = "\n".join(text_parts)
+                if image_count:
+                    summary += f"\n[{image_count} image(s) were attached]"
+                entry["content"] = summary
             role, content = entry.get("role"), entry.get("content")
             if role == "assistant" and not content and not entry.get("tool_calls"):
                 continue

--- a/nocobot/agent.py
+++ b/nocobot/agent.py
@@ -17,9 +17,6 @@ from nocobot.providers import LiteLLMProvider, ToolCallRequest
 class AgentLoop:
     """Agent that processes messages using LLM and MCP tools."""
 
-    _TOOL_RESULT_MAX = 500             # history storage (save-time)
-    _TOOL_RESULT_INFERENCE_MAX = 4000  # current-turn LLM context (execute-time)
-
     def __init__(
         self,
         bus: MessageBus,
@@ -30,6 +27,12 @@ class AgentLoop:
         max_history: int,
         message_timeout: float,
         max_tokens_budget: int,
+        tool_result_max: int = 500,
+        tool_result_inference_max: int = 4000,
+        max_concurrency: int = 3,
+        session_max_idle: float = 3600.0,
+        llm_max_tokens: int = 4096,
+        llm_temperature: float = 0.7,
     ):
         self.bus = bus
         self.mcp = mcp
@@ -37,8 +40,13 @@ class AgentLoop:
         self.max_history = max_history
         self.message_timeout = message_timeout
         self.max_tokens_budget = max_tokens_budget
+        self._tool_result_max = tool_result_max
+        self._tool_result_inference_max = tool_result_inference_max
+        self._session_max_idle = session_max_idle
+        self._llm_max_tokens = llm_max_tokens
+        self._llm_temperature = llm_temperature
         self._running = False
-        self._semaphore = asyncio.Semaphore(3)
+        self._semaphore = asyncio.Semaphore(max_concurrency)
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._tasks: set[asyncio.Task] = set()
         self._session_tasks: dict[str, asyncio.Task] = {}
@@ -105,12 +113,12 @@ class AgentLoop:
         self._session_last_active.pop(msg.session_key, None)
         await self._send_response(msg, "Stopped. Conversation cleared.")
 
-    def _evict_stale_sessions(self, max_idle: float = 3600.0) -> None:
-        """Remove sessions idle longer than max_idle seconds."""
+    def _evict_stale_sessions(self) -> None:
+        """Remove sessions idle longer than session_max_idle seconds."""
         now = time.monotonic()
         stale = [
             key for key, last in self._session_last_active.items()
-            if now - last > max_idle
+            if now - last > self._session_max_idle
         ]
         for key in stale:
             self._history.pop(key, None)
@@ -202,8 +210,8 @@ class AgentLoop:
             response = await self._llm.chat_with_retry(
                 messages=messages,
                 tools=tools if tools else None,
-                max_tokens=4096,
-                temperature=0.7,
+                max_tokens=self._llm_max_tokens,
+                temperature=self._llm_temperature,
             )
 
             # Bail on LLM error — don't append to history (prevents context poisoning)
@@ -304,10 +312,10 @@ class AgentLoop:
             if (
                 role == "tool"
                 and isinstance(content, str)
-                and len(content) > self._TOOL_RESULT_MAX
+                and len(content) > self._tool_result_max
             ):
                 entry["content"] = (
-                    content[: self._TOOL_RESULT_MAX] + "\n... (truncated)"
+                    content[: self._tool_result_max] + "\n... (truncated)"
                 )
             history.append(entry)
         self._trim_history(history)
@@ -328,8 +336,8 @@ class AgentLoop:
         logger.debug(f"Executing tool: {tc.name}")
         try:
             result = await self.mcp.call_tool(tc.name, tc.arguments)
-            if len(result) > self._TOOL_RESULT_INFERENCE_MAX:
-                result = result[:self._TOOL_RESULT_INFERENCE_MAX] + "\n... (truncated)"
+            if len(result) > self._tool_result_inference_max:
+                result = result[:self._tool_result_inference_max] + "\n... (truncated)"
             return result
         except Exception as e:
             logger.exception("Tool execution failed: %s", tc.name)

--- a/nocobot/channels/telegram.py
+++ b/nocobot/channels/telegram.py
@@ -28,9 +28,8 @@ class TelegramConfig:
     rate_limit_window: float = 60.0
     media_max_file_size: int = 20_971_520      # 20 MB
     media_max_total_size: int = 524_288_000     # 500 MB
-
-
-TELEGRAM_MAX_MESSAGE_LEN = 4000
+    max_chunk_length: int = 4000
+    connection_pool_size: int = 16
 
 
 def _enforce_dir_cap(media_dir: "Path", max_total: int) -> None:
@@ -46,7 +45,7 @@ def _enforce_dir_cap(media_dir: "Path", max_total: int) -> None:
         logger.debug(f"Deleted oldest media file: {oldest.name}")
 
 
-def _split_message(text: str, max_len: int = TELEGRAM_MAX_MESSAGE_LEN) -> list[str]:
+def _split_message(text: str, max_len: int = 4000) -> list[str]:
     """Split text into chunks, preferring line breaks, then spaces, then hard cut."""
     if len(text) <= max_len:
         return [text]
@@ -231,7 +230,7 @@ class TelegramChannel(BaseChannel):
         self._running = True
         
         # Build the application with larger connection pool to avoid pool-timeout on long runs
-        req = HTTPXRequest(connection_pool_size=16, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0)
+        req = HTTPXRequest(connection_pool_size=self.config.connection_pool_size, pool_timeout=5.0, connect_timeout=30.0, read_timeout=30.0)
         builder = Application.builder().token(self.config.token).request(req).get_updates_request(req)
         if self.config.proxy:
             builder = builder.proxy(self.config.proxy).get_updates_proxy(self.config.proxy)
@@ -326,7 +325,7 @@ class TelegramChannel(BaseChannel):
             await self._send_text(chat_id, msg.content, reply_params=reply_params)
         else:
             self._stop_typing(msg.chat_id)
-            chunks = _split_message(msg.content)
+            chunks = _split_message(msg.content, max_len=self.config.max_chunk_length)
             for i, chunk in enumerate(chunks):
                 rp = reply_params if i == 0 else None
                 await self._send_with_streaming(chat_id, chunk, reply_params=rp)

--- a/nocobot/config.py
+++ b/nocobot/config.py
@@ -35,6 +35,11 @@ class Config(BaseSettings):
     llm_max_tokens: int = 4096
     llm_temperature: float = 0.7
 
+    # Vision
+    vision_max_images: int = 5
+    vision_max_long_edge: int = 1024
+    vision_detail: str = "low"          # "low", "high", or "auto"
+
     # Input validation
     max_message_length: int = 4096
 

--- a/nocobot/config.py
+++ b/nocobot/config.py
@@ -1,5 +1,7 @@
 """Configuration for nocobot - NocoDB Telegram Agent."""
 
+from typing import Literal
+
 from pydantic_settings import BaseSettings
 
 
@@ -38,7 +40,7 @@ class Config(BaseSettings):
     # Vision
     vision_max_images: int = 5
     vision_max_long_edge: int = 1024
-    vision_detail: str = "low"          # "low", "high", or "auto"
+    vision_detail: Literal["low", "high", "auto"] = "low"
 
     # Input validation
     max_message_length: int = 4096

--- a/nocobot/config.py
+++ b/nocobot/config.py
@@ -25,12 +25,26 @@ class Config(BaseSettings):
     agent_max_history: int = 40
     agent_max_tokens: int = 200_000
 
+    # Agent tuning
+    agent_tool_result_max: int = 500
+    agent_tool_result_inference_max: int = 4000
+    agent_max_concurrency: int = 3
+    agent_session_max_idle: float = 3600.0
+
+    # LLM defaults
+    llm_max_tokens: int = 4096
+    llm_temperature: float = 0.7
+
     # Input validation
     max_message_length: int = 4096
 
     # Media file limits
     media_max_file_size: int = 20_971_520      # 20 MB per file
     media_max_total_size: int = 524_288_000     # 500 MB total media dir cap
+
+    # Telegram transport
+    telegram_max_chunk_length: int = 4000
+    telegram_connection_pool_size: int = 16
 
     # Per-user rate limiting
     rate_limit_messages: int = 10

--- a/nocobot/main.py
+++ b/nocobot/main.py
@@ -65,6 +65,9 @@ async def main() -> None:
         session_max_idle=config.agent_session_max_idle,
         llm_max_tokens=config.llm_max_tokens,
         llm_temperature=config.llm_temperature,
+        vision_max_images=config.vision_max_images,
+        vision_max_long_edge=config.vision_max_long_edge,
+        vision_detail=config.vision_detail,
     )
 
     # Set up graceful shutdown

--- a/nocobot/main.py
+++ b/nocobot/main.py
@@ -44,6 +44,8 @@ async def main() -> None:
         rate_limit_window=config.rate_limit_window,
         media_max_file_size=config.media_max_file_size,
         media_max_total_size=config.media_max_total_size,
+        max_chunk_length=config.telegram_max_chunk_length,
+        connection_pool_size=config.telegram_connection_pool_size,
     )
     telegram = TelegramChannel(telegram_config, bus)
 
@@ -57,6 +59,12 @@ async def main() -> None:
         max_history=config.agent_max_history,
         message_timeout=config.agent_message_timeout,
         max_tokens_budget=config.agent_max_tokens,
+        tool_result_max=config.agent_tool_result_max,
+        tool_result_inference_max=config.agent_tool_result_inference_max,
+        max_concurrency=config.agent_max_concurrency,
+        session_max_idle=config.agent_session_max_idle,
+        llm_max_tokens=config.llm_max_tokens,
+        llm_temperature=config.llm_temperature,
     )
 
     # Set up graceful shutdown

--- a/nocobot/pyproject.toml
+++ b/nocobot/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "loguru>=0.7.0",
     "httpx>=0.25.0",
+    "Pillow>=10.0.0",
 ]
 
 [project.optional-dependencies]

--- a/nocobot/vision.py
+++ b/nocobot/vision.py
@@ -1,0 +1,95 @@
+"""Image vision utilities - resize, encode, build content blocks."""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+
+from loguru import logger
+from PIL import Image
+
+_MIME_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+_IMAGE_EXTENSIONS = set(_MIME_TYPES.keys())
+
+
+def is_image(path: str) -> bool:
+    """Check if a file path has a known image extension."""
+    return Path(path).suffix.lower() in _IMAGE_EXTENSIONS
+
+
+def encode_image(
+    path: str,
+    max_long_edge: int = 1024,
+    jpeg_quality: int = 85,
+) -> tuple[str, str]:
+    """Resize and base64-encode an image file.
+
+    Returns (data_uri, mime_type).
+    """
+    p = Path(path)
+    mime = _MIME_TYPES.get(p.suffix.lower(), "image/jpeg")
+
+    with Image.open(p) as img:
+        if img.mode in ("RGBA", "P"):
+            img = img.convert("RGB")
+            mime = "image/jpeg"
+
+        w, h = img.size
+        if max(w, h) > max_long_edge:
+            scale = max_long_edge / max(w, h)
+            img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+
+        buf = io.BytesIO()
+        fmt = "PNG" if mime == "image/png" else "JPEG"
+        save_kwargs = {"quality": jpeg_quality} if fmt == "JPEG" else {}
+        img.save(buf, format=fmt, **save_kwargs)
+
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:{mime};base64,{b64}", mime
+
+
+def build_vision_content(
+    text: str,
+    media_paths: list[str],
+    *,
+    max_images: int = 5,
+    max_long_edge: int = 1024,
+    detail: str = "low",
+) -> list[dict]:
+    """Build OpenAI multipart content blocks from text + image paths.
+
+    Non-image files are skipped. Encoding errors become text placeholders.
+    """
+    parts: list[dict] = []
+
+    if text:
+        parts.append({"type": "text", "text": text})
+
+    image_count = 0
+    for path in media_paths:
+        if not is_image(path):
+            continue
+        if image_count >= max_images:
+            remaining = sum(1 for p in media_paths if is_image(p)) - max_images
+            parts.append({"type": "text", "text": f"[{remaining} more image(s) omitted]"})
+            break
+        try:
+            data_uri, _ = encode_image(path, max_long_edge=max_long_edge)
+            parts.append({
+                "type": "image_url",
+                "image_url": {"url": data_uri, "detail": detail},
+            })
+            image_count += 1
+        except Exception as e:
+            logger.warning(f"Failed to encode image {path}: {e}")
+            parts.append({"type": "text", "text": "[image: failed to process]"})
+
+    return parts


### PR DESCRIPTION
## Summary
Closes #15

- Promote hardcoded tuning constants (rate limits, timeouts, vision settings, media limits, etc.) to `config.py` as pydantic-settings fields with env var support
- Add image vision support — Telegram photos/documents are downloaded, resized, base64-encoded, and sent as multipart content to the LLM
- Validate `vision_detail` with `Literal["low", "high", "auto"]` instead of free-form string
- Fix Dockerfile `HOME` directory for media downloads
- Strip `[image: path]` text artifacts from vision messages

## Test plan
- [x] Verify bot starts with default config (no new env vars required)
- [x] Confirm invalid `VISION_DETAIL` value (e.g. `medium`) raises `ValidationError` at startup
- [x] Send a photo to the bot and verify it processes the image via vision
- [x] Confirm media files are cleaned up and size limits are respected